### PR TITLE
enable sourcemaps from typescript through rollup.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "devDependencies": {
     "rollup": "^0.34.1",
-    "typescript": "^1.8.10",
-    "rollup-watch": "^2.5.0"
+    "rollup-plugin-typescript": "^0.7.7",
+    "rollup-watch": "^2.5.0",
+    "typescript": "^1.8.10"
   },
   "scripts": {
-    "typescript": "tsc -m es2015 -t es6 --watch *.ts --sourceMap --outDir dist",
-    "rollup": "rollup -m -w --input dist/index.js --output dist/dist.js"
+    "watch": "rollup --watch --config"
   }
 }

--- a/readme
+++ b/readme
@@ -1,4 +1,3 @@
-dev: in 2 tabs run in this order
+dev: 
 
-npm run typescript
-npm run rollup
+`npm run watch`

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,10 @@
+import typescript from 'rollup-plugin-typescript';
+
+export default {
+  entry: './index.ts',
+  plugins: [
+    typescript()
+  ],
+  sourceMap: true,
+  dest: 'dist/dist.js'
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "compilerOptions": {
+        "module": "es2015",
+        "target": "es6",
+        "outDir": "dist",
+        "sourceMap": true
+    }
+}


### PR DESCRIPTION
[`rollup-plugin-typescript`](https://github.com/rollup/rollup-plugin-typescript) enables things. Rollup can't do input sourcemaps on the command-line

![image](https://cloud.githubusercontent.com/assets/39191/17468206/5154c4b2-5cda-11e6-8d26-00db07fb2467.png)

Two new config files.

`npm run watch` instead of the two separate ones.
